### PR TITLE
Afrouxamento do CoC

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -13,33 +13,36 @@ Estar de acordo com as regras privadas de nossa comunidade torna mais eficiente 
 
 As diretivas a seguir são regras para conversa civilizada e convivência ao mesmo tempo em que se preza a liberdade de expressão e confronto de ideias. Este código de conduta é um conjunto de regras para orientar e disciplinar a conduta dos membros enquanto participantes ativos da comunidade.
 
+Em resumo, **apenas tenha bom senso**. Os moderadores só irão intervir se for realmente necessário.
+
 ---
 #### Não serão tolerados em nossos grupos:
-- Comportamentos propositalmente e insistentemente insultuosos com finalidade clara de desestabilizar emocionalmente outras pessoas. "Ofensa" é a interpretação do receptor, "insulto" a do emissor: se uma pessoa se ofende por não gostar de mulheres sem véu, não há que se tentar agradá-la pra não ser ofendida; por outro lado, se alguém chama outrem de "peão" para inferiorizá-la, mesmo que essa pessoa não se sinta ofendida, isso pede intervenção;
-- Discussões acaloradas em que várias pessoas se insultem mutuamente;
+- Comportamentos propositalmente e insistentemente insultuosos feitas por uma ou mais pessoas, com finalidade clara de desestabilizar emocionalmente outras pessoas. Palavras não machucam mas ofensas desvirtuam uma discussão saudáveis;
 - Ameaça séria e crível de violência física contra outro membro;
 - Doxxing de membros (revelação de dados privados, como endereço, RG, cartão de crédito);
 - Comportamentos scriptados/automáticos de flood/spam, anúncios/publicidade de usuário que não participa do grupo ou acaba de entrar ou não-autorizada;
 - Links ou chamadas suspeitas/enganosas ou tentativa de enganar usuários com scam, golpes, fraude ou outros atos claramente ilegais;
-- Offtopic ostensivo ou inflamado que claramente não agregue conteúdo ao grupo e ao contrário até impeça debates construtivos (há que se ter muito cuidado com a interpretação aqui);
+- Offtopic extremamente ostensivo ou inflamado que claramente não agregue conteúdo ao grupo e ao contrário até impeça debates construtivos;
 - Conteúdos que se encaixem em _NSFW_ (Not Safe for Work, ou Inapropriado Pra Ver no Trabalho).
 
 #### Moderadores do grupo devem ter comportamento justo e equilibrado, sem vieses, saber manter a calma em discussão acalorada e também não podem exceder as penalidades:
-- Moderadores não podem aplicar penalidades maiores que as descritas na [lista de penalidades](https://github.com/cypherpunksbr/comunidade/blob/main/penalidades.md);
+- Moderadores devem sempre ser imparciais, usar do bom senso e não podem aplicar penalidades incondizentes com as descritas na [lista de penalidades](https://github.com/cypherpunksbr/comunidade/blob/main/penalidades.md);
 - Moderadores também são membros da comunidade, portanto, também devem seguir as regras;
 - Moderadores não podem fazer ameaças constantes de punição a usuários, com viés claro ou para motivos pessoais verificáveis.
 
-Assuntos diversos fora do contexto do grupo tendem a gerar desentendimentos não produtivos e divisões na comunidade. Caso queira interagir com os membros sobre assuntos não relacionados ao tema do grupo principal, busque pelos grupos _offtopic_, onde as regras são pouco rígidas e as discussões mais descontraídas.
+Sinta-se a vontade para postar no grupo, apenas evite assuntos que são totalmente desconexos com os assuntos abordados no grupo (discutir futebol, biscoito ou bolacha e dicas de moda não tem nenhuma conexão com o grupo principal e é desejável que seja postado no _offtopic_.
 
-Respeite a todos em nossa comunidade, não importando suas crenças religiosas, etnia ou ideologias. De forma simples, trate os outros da forma que gostaria de ser tratado; respeite os outros e seus pontos de vista, mesmo que discorde deles. Quando você se perceber discordando; contrarie a ideia ou o argumento. Não inicie ataques _ad hominem_.
+Respeite a todos em nossa comunidade, não importando suas crenças religiosas, etnia ou ideologias. De forma simples, trate os outros da forma que gostaria de ser tratado. Respeite os outros e seus pontos de vista, mesmo que discorde deles. Quando discordar, busque contrariar a ideia ou o argumento com um contra-argumento. Não use de falácias.
 
 Tenha responsabilidade sobre suas atitudes. Não nos responsabilizamos pelo que você mostrar e dizer nem pelo que você ver e ouvir.
 
 Cuidado com o que fala! Estando em um grupo aberto você sempre estará susceptível a estar sendo vigiado por entidades estatais ou seus aliados que podem tentar te prejudicar por palavras que você escreveu em nosso grupo, não importando se é certo ou errado, mas baseado em julgamentos subjetivos feitos a bel-prazer destas entidades.
 
-Envie mensagens legíveis, concisas e agrupadas. Ao postar links, remova os rastreadores que ficam geralmente no final dos links. Ao postar código maior que 5 linhas, use pastebin ou plataformas git, compartilhando o link no grupo.
+Envie mensagens legíveis, concisas e agrupadas. Ao postar links, tente remover os rastreadores que ficam geralmente no final dos links. Ao postar código maior que 5 linhas, use pastebin ou plataformas git, compartilhando o link no grupo.
 
 ---
+Este CoC está disponível no GitHub justamente para que você possa sugerir alterações. Iremos analisar e se houver concordância a alteração será aceita, caso contrário iremos discutir soluções até chegar em uma melhoria.
+
 Nós não somos uma comunidade “democrática”. As decisões não são tomadas pela maioria, estamos mais próximos de uma meritocracia do que de uma democracia.
 
 Somos uma comunidade com regras privadas. Sua permanência em nossos grupos interativos depende do respeito destas regras.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-# Cypherpunks Brasil - Código de Conduta
+# Cypherpunks Brasil - Código de Conduta da Comunidade
 
 Seja bem-vindo e encorajado a buscar conhecimento, contribuir com a comunidade e abraçar nossos princípios éticos e morais.
 
@@ -11,7 +11,7 @@ Quando buscar ajuda, faça suas pesquisas primeiro e exiba detalhes daquilo que 
 
 Estar de acordo com as regras privadas de nossa comunidade torna mais eficiente e agradável a interação entre membros e devem ser seguidas em nossos grupos abertos para interação.
 
-As diretivas a seguir são regras para conversa civilizada e convivência ao mesmo tempo em que se preza a liberdade de expressão e confronto de ideias. Este código de conduta é um conjunto de regras para orientar e disciplinar a conduta dos membros enquanto participantes ativos da comunidade.
+As diretivas a seguir são regras para conversa civilizada e convivência ao mesmo tempo em que se preza a liberdade de expressão e confronto de ideias. Este Código de Conduta é um conjunto de regras para orientar os membros enquanto participantes da comunidade.
 
 Em resumo, **apenas tenha bom senso**. Os moderadores só irão intervir se for realmente necessário.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,6 @@
-# Cypherpunks Brasil - Código de Conduta da Comunidade
+# Cypherpunks Brasil - Regras do Grupo
 
-Seja bem-vindo e encorajado a buscar conhecimento, contribuir com a comunidade e abraçar nossos princípios éticos e  morais.
+Seja bem-vindo e encorajado a buscar conhecimento, contribuir com a comunidade e abraçar nossos princípios éticos e morais.
 
 Somos um grupos de pessoas e ciborgues com interesses nas áreas de criptografia, criptomoedas, criptoanarquismo, economia, segurança, privacidade, liberdade, sobrevivencialismo, agorismo, libertarianismo, programação e outras áreas da tecnologia.
 
@@ -11,12 +11,23 @@ Quando buscar ajuda, faça suas pesquisas primeiro e exiba detalhes daquilo que 
 
 Estar de acordo com as regras privadas de nossa comunidade torna mais eficiente e agradável a interação entre membros e devem ser seguidas em nossos grupos abertos para interação.
 
+As diretivas a seguir são regras para conversa civilizada e convivência ao mesmo tempo em que se preza a liberdade de expressão e confronto de ideias; não são um código de conduta pois conduta é algo tão pessoal quanto propriedade privada e não cabe a ninguém legislar sobre a dos outros.
+
 ---
 #### Não serão tolerados em nossos grupos:
-- Comportamentos ofensivos e brigas entre membros, que incluem iniciação de agressão contra pessoas pacíficas, violação de liberdade e propriedade privada, denegrir a imagem de membros ou da comunidade, trollagens entre outros;
-- Spam, links encurtados, publicidade não autorizada, flood, golpes e compartilhamento de links que possam levar a membros a caírem em golpes ou serem prejudicados, com ou sem intenções pessoais;
-- Politicagem, nacionalismo, religião, esportes no geral entre outros fora do contexto do grupo;
-- Conteúdos que se encaixem em _NSFW_.
+- Comportamentos propositalmente e insistentemente insultuosos com finalidade clara de desestabilizar emocionalmente outras pessoas. "Ofensa" é a interpretação do receptor, "insulto" a do emissor: se uma pessoa se ofende por não gostar de mulheres sem véu, não há que se tentar agradá-la pra não ser ofendida; por outro lado, se alguém chama outrem de "peão" para inferiorizá-la, mesmo que essa pessoa não se sinta ofendida, isso pede intervenção. **Penalidade**: uma pessoa que insista em insultar os outros é inicialmente mutada no grupo por um dia. Após um dia o mute é tirado, e se incidir novamente toma expulsão do grupo de uma semana. Se depois disso ainda repetir, é expulsa permanentemente do grupo.
+- Discussões acaloradas em que várias pessoas se insultem mutuamente. **Penalidade** neste caso, com várias pessoas com os ânimos acirrados, para não ser injusto o melhor é mutar todos os membros por uma hora para dar tempo de esfriarem a cabeça. Caso alguns continuem com o bate-boca, passa a valer a regra individual dos insultos.
+- Ameaça séria e crível de violência física contra outro membro. **Penalidade**: ban imediato e permanente.
+- Doxxing (revelação de dados privados, como endereço, RG, cartão de crédito) de outras pessoas, sejam membros do grupo ou não. **Penalidade**: ban imediato e permanente.
+- Comportamentos scriptados/automáticos de flood/spam, anúncios/publicidade de usuário que não participa do grupo ou acaba de entrar ou não-autorizada. **Penalidade**: ban de um dia. Em caso de reincorrência, ban permanente.
+- Links ou chamadas suspeitas/enganosas ou tentativa de enganar usuários com scam, golpes, fraude ou outros atos claramente ilegais. **Penalidade**: ban imediato e permanente.
+- Offtopic ostensivo ou inflamado que claramente não agregue conteúdo ao grupo e ao contrário até impeça debates construtivos (há que se ter muito cuidado com a interpretação aqui). **Penalidade**: ban de uma hora; em reincorrência, ban de um dia; em nova reincorrência, ban permanente.
+- Conteúdos que se encaixem em _NSFW_ (Non-Safe For Work, ou Inapropriado Pra Ver no Trabalho). **Penalidade**: ban de uma hora; em reincorrência, ban de um dia; em nova reincorrência, ban permanente.
+
+#### Moderadores do grupo devem ter comportamento justo e equilibrado, sem vieses, saber manter a calma em discussão acalorada e também não podem exceder as penalidades:
+- Moderador que exerça penalidades maiores que as descritas nas regras deve receber uma advertência; se repetir, deve ser temporariamente destituído do poder de moderador por uma semana. E se repetir novamente, deve ser desligado do quadro de moderadores.
+- Moderador que tiver comportamento inapropriado como o das regras para usuário -- como por exemplo fazer floods ou insultar outros usuários -- deve, ao invés de receber a penalidade de usuário, ser destituído do cargo de moderador, sem ser expulso do grupo. Só a partir desse momento, como usuário, regras comuns passam a valer para ele.
+- Moderador que estiver fazendo ameaças constantes a usuários de punição, com viés claro ou para motivos pessoais verificáveis, desse receber uma advertência sobre tal comportamento. Se continuar fazendo o mesmo, deve ser temporariamente destituído da moderação por uma semana. Voltando a repetir, será permanentemente removido da administração do grupo.
 
 Assuntos diversos fora do contexto do grupo tendem a gerar desentendimentos não produtivos e divisões na comunidade. Caso queira interagir com os membros sobre assuntos não relacionados ao tema do grupo principal, busque pelos grupos _offtopic_, onde as regras são pouco rígidas e as discussões mais descontraídas.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -17,12 +17,11 @@ Em resumo, **apenas tenha bom senso**. Os moderadores só irão intervir se for 
 
 ---
 #### Não serão tolerados em nossos grupos:
-- Comportamentos propositalmente e insistentemente insultuosos feitas por uma ou mais pessoas, com finalidade clara de desestabilizar emocionalmente outras pessoas. Palavras não machucam mas ofensas desvirtuam uma discussão saudáveis;
+- Comportamentos propositalmente e insistentemente insultuosos feitas por uma ou mais pessoas, com finalidade clara de desestabilizar emocionalmente outras pessoas. Palavras não machucam mas ofensas desvirtuam uma discussão saudável;
 - Ameaça séria e crível de violência física contra outro membro;
 - Doxxing de membros (revelação de dados privados, como endereço, RG, cartão de crédito);
 - Comportamentos scriptados/automáticos de flood/spam, anúncios/publicidade de usuário que não participa do grupo ou acaba de entrar ou não-autorizada;
-- Links ou chamadas suspeitas/enganosas ou tentativa de enganar usuários com scam, golpes, fraude ou outros atos claramente ilegais;
-- Offtopic extremamente ostensivo ou inflamado que claramente não agregue conteúdo ao grupo e ao contrário até impeça debates construtivos;
+- Links ou chamadas suspeitas/enganosas ou tentativa de enganar usuários com scam, golpes, fraude ou outros atos claramente anti-éticos;
 - Conteúdos que se encaixem em _NSFW_ (Not Safe for Work, ou Inapropriado Pra Ver no Trabalho).
 
 #### Moderadores do grupo devem ter comportamento justo e equilibrado, sem vieses, saber manter a calma em discussão acalorada e também não podem exceder as penalidades:
@@ -30,7 +29,7 @@ Em resumo, **apenas tenha bom senso**. Os moderadores só irão intervir se for 
 - Moderadores também são membros da comunidade, portanto, também devem seguir as regras;
 - Moderadores não podem fazer ameaças constantes de punição a usuários, com viés claro ou para motivos pessoais verificáveis.
 
-Sinta-se a vontade para postar no grupo, apenas evite assuntos que são totalmente desconexos com os assuntos abordados no grupo (discutir futebol, biscoito ou bolacha e dicas de moda não tem nenhuma conexão com o grupo principal e é desejável que seja postado no _offtopic_.
+Sinta-se a vontade para postar no grupo, apenas evite assuntos que são totalmente desconexos com os assuntos abordados no grupo. Discutir futebol, biscoito ou bolacha e dicas de moda não tem nenhuma conexão com o grupo principal e é desejável que seja postado no _offtopic_.
 
 Respeite a todos em nossa comunidade, não importando suas crenças religiosas, etnia ou ideologias. De forma simples, trate os outros da forma que gostaria de ser tratado. Respeite os outros e seus pontos de vista, mesmo que discorde deles. Quando discordar, busque contrariar a ideia ou o argumento com um contra-argumento. Não use de falácias.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-# Cypherpunks Brasil - Regras do Grupo
+# Cypherpunks Brasil - Código de Conduta
 
 Seja bem-vindo e encorajado a buscar conhecimento, contribuir com a comunidade e abraçar nossos princípios éticos e morais.
 
@@ -11,23 +11,23 @@ Quando buscar ajuda, faça suas pesquisas primeiro e exiba detalhes daquilo que 
 
 Estar de acordo com as regras privadas de nossa comunidade torna mais eficiente e agradável a interação entre membros e devem ser seguidas em nossos grupos abertos para interação.
 
-As diretivas a seguir são regras para conversa civilizada e convivência ao mesmo tempo em que se preza a liberdade de expressão e confronto de ideias; não são um código de conduta pois conduta é algo tão pessoal quanto propriedade privada e não cabe a ninguém legislar sobre a dos outros.
+As diretivas a seguir são regras para conversa civilizada e convivência ao mesmo tempo em que se preza a liberdade de expressão e confronto de ideias. Este código de conduta é um conjunto de regras para orientar e disciplinar a conduta dos membros enquanto participantes ativos da comunidade.
 
 ---
 #### Não serão tolerados em nossos grupos:
-- Comportamentos propositalmente e insistentemente insultuosos com finalidade clara de desestabilizar emocionalmente outras pessoas. "Ofensa" é a interpretação do receptor, "insulto" a do emissor: se uma pessoa se ofende por não gostar de mulheres sem véu, não há que se tentar agradá-la pra não ser ofendida; por outro lado, se alguém chama outrem de "peão" para inferiorizá-la, mesmo que essa pessoa não se sinta ofendida, isso pede intervenção. **Penalidade**: uma pessoa que insista em insultar os outros é inicialmente mutada no grupo por um dia. Após um dia o mute é tirado, e se incidir novamente toma expulsão do grupo de uma semana. Se depois disso ainda repetir, é expulsa permanentemente do grupo.
-- Discussões acaloradas em que várias pessoas se insultem mutuamente. **Penalidade** neste caso, com várias pessoas com os ânimos acirrados, para não ser injusto o melhor é mutar todos os membros por uma hora para dar tempo de esfriarem a cabeça. Caso alguns continuem com o bate-boca, passa a valer a regra individual dos insultos.
-- Ameaça séria e crível de violência física contra outro membro. **Penalidade**: ban imediato e permanente.
-- Doxxing (revelação de dados privados, como endereço, RG, cartão de crédito) de outras pessoas, sejam membros do grupo ou não. **Penalidade**: ban imediato e permanente.
-- Comportamentos scriptados/automáticos de flood/spam, anúncios/publicidade de usuário que não participa do grupo ou acaba de entrar ou não-autorizada. **Penalidade**: ban de um dia. Em caso de reincorrência, ban permanente.
-- Links ou chamadas suspeitas/enganosas ou tentativa de enganar usuários com scam, golpes, fraude ou outros atos claramente ilegais. **Penalidade**: ban imediato e permanente.
-- Offtopic ostensivo ou inflamado que claramente não agregue conteúdo ao grupo e ao contrário até impeça debates construtivos (há que se ter muito cuidado com a interpretação aqui). **Penalidade**: ban de uma hora; em reincorrência, ban de um dia; em nova reincorrência, ban permanente.
-- Conteúdos que se encaixem em _NSFW_ (Non-Safe For Work, ou Inapropriado Pra Ver no Trabalho). **Penalidade**: ban de uma hora; em reincorrência, ban de um dia; em nova reincorrência, ban permanente.
+- Comportamentos propositalmente e insistentemente insultuosos com finalidade clara de desestabilizar emocionalmente outras pessoas. "Ofensa" é a interpretação do receptor, "insulto" a do emissor: se uma pessoa se ofende por não gostar de mulheres sem véu, não há que se tentar agradá-la pra não ser ofendida; por outro lado, se alguém chama outrem de "peão" para inferiorizá-la, mesmo que essa pessoa não se sinta ofendida, isso pede intervenção;
+- Discussões acaloradas em que várias pessoas se insultem mutuamente;
+- Ameaça séria e crível de violência física contra outro membro;
+- Doxxing de membros (revelação de dados privados, como endereço, RG, cartão de crédito);
+- Comportamentos scriptados/automáticos de flood/spam, anúncios/publicidade de usuário que não participa do grupo ou acaba de entrar ou não-autorizada;
+- Links ou chamadas suspeitas/enganosas ou tentativa de enganar usuários com scam, golpes, fraude ou outros atos claramente ilegais;
+- Offtopic ostensivo ou inflamado que claramente não agregue conteúdo ao grupo e ao contrário até impeça debates construtivos (há que se ter muito cuidado com a interpretação aqui);
+- Conteúdos que se encaixem em _NSFW_ (Not Safe for Work, ou Inapropriado Pra Ver no Trabalho).
 
 #### Moderadores do grupo devem ter comportamento justo e equilibrado, sem vieses, saber manter a calma em discussão acalorada e também não podem exceder as penalidades:
-- Moderador que exerça penalidades maiores que as descritas nas regras deve receber uma advertência; se repetir, deve ser temporariamente destituído do poder de moderador por uma semana. E se repetir novamente, deve ser desligado do quadro de moderadores.
-- Moderador que tiver comportamento inapropriado como o das regras para usuário -- como por exemplo fazer floods ou insultar outros usuários -- deve, ao invés de receber a penalidade de usuário, ser destituído do cargo de moderador, sem ser expulso do grupo. Só a partir desse momento, como usuário, regras comuns passam a valer para ele.
-- Moderador que estiver fazendo ameaças constantes a usuários de punição, com viés claro ou para motivos pessoais verificáveis, desse receber uma advertência sobre tal comportamento. Se continuar fazendo o mesmo, deve ser temporariamente destituído da moderação por uma semana. Voltando a repetir, será permanentemente removido da administração do grupo.
+- Moderadores não podem aplicar penalidades maiores que as descritas na [lista de penalidades](https://github.com/cypherpunksbr/comunidade/blob/main/penalidades.md);
+- Moderadores também são membros da comunidade, portanto, também devem seguir as regras;
+- Moderadores não podem fazer ameaças constantes de punição a usuários, com viés claro ou para motivos pessoais verificáveis.
 
 Assuntos diversos fora do contexto do grupo tendem a gerar desentendimentos não produtivos e divisões na comunidade. Caso queira interagir com os membros sobre assuntos não relacionados ao tema do grupo principal, busque pelos grupos _offtopic_, onde as regras são pouco rígidas e as discussões mais descontraídas.
 

--- a/penalidades.md
+++ b/penalidades.md
@@ -13,7 +13,7 @@
 | Tentativa de enganar usuários com scam, golpes, fraude ou outros atos claramente ilegais | ban | - | - |
 | Offtopic extremamente ostensivo ou inflamado | Envio do link para o offtopic, mute de 1 hora | Envio do link para o offtopic, mute de 1 dia | Envio do link para o offtopic, mute de 2 dias a cada incidente |
 | Conteúdos _NSFW_, como pornografia, gore, etc. | Mensagem apagada, mute de 6 horas | Mensagem apagada, mute de 5 dias | Mensagem apagada, mute de 2 semanas a cada incidente |
-| Moderador fazendo ameaças constantes de punição a usuários, com viés claro ou para motivos pessoais verificáveis | Retiradas permissões para aplicar penalidades por 1 dia | Retiradas permissões para aplicar penalidades por 1 semana | Reavaliação da posição como moderador |
+| Moderador fazendo ameaças constantes de punição a usuários, com viés claro ou para motivos pessoais verificáveis | Retiradas permissões para aplicar penalidades por 1 semana | Retiradas permissões para aplicar penalidades por 2 semanas | Reavaliação da posição como moderador |
 
 - Moderadores que descumpram as regras que são válidas para todos os usuários tem suas permissões para aplicar penalidades retiradas e recebem a mesma penalidade que um usuário comum recebe, recebendo novamente as permissões para aplicar penalidades apenas após cumprir a penalidade recebida.
 

--- a/penalidades.md
+++ b/penalidades.md
@@ -1,20 +1,22 @@
 # Lista de Penalidades
 
->Penalidades aplicáveis a membros que descumpram com as regras listadas em nosso código de conduta.
+>Penalidades aplicÃ¡veis a membros que descumpram com as regras listadas em nosso cÃ³digo de conduta.
 
 #### Penalidades para o grupo Cypherpunks Brasil no telegram:
 
-| Ocorrência | 1º incidente | 2º incidente | 3º incidente + |
+| OcorrÃªncia | 1Âº incidente | 2Âº incidente | 3Âº incidente + |
 |------------|--------------|--------------|----------------|
-| Comportamentos propositalmente e insistentemente insultuosos e/ou discussões acaloradas em que várias pessoas se insultem mutuamente | Mensagem apagada, mute de 6 horas | Mensagem apagada, mute de 2 dias | Mensagem apagada, mutes de 2 semanas |
-| Ameaça séria e crível de violência física contra outro membro | Mensagem apagada, ban | - | - |
+| Comportamentos propositalmente e insistentemente insultuosos e/ou discussÃµes acaloradas em que vÃ¡rias pessoas se insultem mutuamente | Mensagem apagada, mute de 6 horas | Mensagem apagada, mute de 2 dias | Mensagem apagada, mutes de 2 semanas |
+| AmeaÃ§a sÃ©ria e crÃ­vel de violÃªncia fÃ­sica contra outro membro | Mensagem apagada, ban | - | - |
 | Doxxing de membros | Mensagem apagada, ban | - | - |
-| Comportamentos scriptados/automáticos de flood/spam, anúncios/publicidade de usuário que não participa do grupo ou acaba de entrar ou não-autorizada | mute de 2 dias | mute de 2 semanas | ban |
-| Tentativa de enganar usuários com scam, golpes, fraude ou outros atos claramente ilegais | ban | - | - |
-| Offtopic ostensivo ou inflamado | Envio do link para o offtopic, mute de 1 hora | Envio do link para o offtopic, mute de 1 dia | Envio do link para o offtopic, mute de 2 dias a cada incidente |
-| Conteúdos _NSFW_ | Mensagem apagada, mute de 6 horas | Mensagem apagada, mute de 5 dias | Mensagem apagada, mute de 2 semanas a cada incidente |
-| Moderado fazendo ameaças constantes de punição a usuários, com viés claro ou para motivos pessoais verificáveis | Retiradas permissões para aplicar penalidades por 1 dia | Retiradas permissões para aplicar penalidades por 1 semana | Reavaliação da posição como moderador |
+| Comportamentos scriptados/automÃ¡ticos de flood/spam, anÃºncios/publicidade de usuÃ¡rio que nÃ£o participa do grupo ou acaba de entrar ou nÃ£o-autorizada | mute de 2 dias | mute de 2 semanas | ban |
+| Tentativa de enganar usuÃ¡rios com scam, golpes, fraude ou outros atos claramente ilegais | ban | - | - |
+| Offtopic extremamente ostensivo ou inflamado | Envio do link para o offtopic, mute de 1 hora | Envio do link para o offtopic, mute de 1 dia | Envio do link para o offtopic, mute de 2 dias a cada incidente |
+| ConteÃºdos _NSFW_, como pornografia, gore, etc. | Mensagem apagada, mute de 6 horas | Mensagem apagada, mute de 5 dias | Mensagem apagada, mute de 2 semanas a cada incidente |
+| Moderado fazendo ameaÃ§as constantes de puniÃ§Ã£o a usuÃ¡rios, com viÃ©s claro ou para motivos pessoais verificÃ¡veis | Retiradas permissÃµes para aplicar penalidades por 1 dia | Retiradas permissÃµes para aplicar penalidades por 1 semana | ReavaliaÃ§Ã£o da posiÃ§Ã£o como moderador |
 
-- Moderadores que descumpram as regras que são válidas para todos os usuários tem suas permissões para aplicar penalidades retiradas e recebem a mesma penalidade que um usuário comum recebe, recebendo novamente as permissões para aplicar penalidades apenas após cumprir a penalidade recebida.
+- Moderadores que descumpram as regras que sÃ£o vÃ¡lidas para todos os usuÃ¡rios tem suas permissÃµes para aplicar penalidades retiradas e recebem a mesma penalidade que um usuÃ¡rio comum recebe, recebendo novamente as permissÃµes para aplicar penalidades apenas apÃ³s cumprir a penalidade recebida.
 
-As regras listadas estão simplificadas, porém em concordância com o [Código de Conduta](https://github.com/cypherpunksbr/comunidade/blob/main/CODE_OF_CONDUCT.md).
+- Os moderadores tem autonomia para penalizar usuÃ¡rios e as penalidades podem ser sutilmente alteradas caso os casos tenham gravidade menor ou maior, jamais levando para o lado pessoal. Moderadores que nÃ£o usarem do bom senso serÃ£o afastados.
+
+As regras listadas estÃ£o simplificadas, porÃ©m em concordÃ¢ncia com o [CÃ³digo de Conduta](https://github.com/cypherpunksbr/comunidade/blob/main/CODE_OF_CONDUCT.md).

--- a/penalidades.md
+++ b/penalidades.md
@@ -13,7 +13,7 @@
 | Tentativa de enganar usuários com scam, golpes, fraude ou outros atos claramente ilegais | ban | - | - |
 | Offtopic extremamente ostensivo ou inflamado | Envio do link para o offtopic, mute de 1 hora | Envio do link para o offtopic, mute de 1 dia | Envio do link para o offtopic, mute de 2 dias a cada incidente |
 | Conteúdos _NSFW_, como pornografia, gore, etc. | Mensagem apagada, mute de 6 horas | Mensagem apagada, mute de 5 dias | Mensagem apagada, mute de 2 semanas a cada incidente |
-| Moderado fazendo ameaças constantes de punição a usuários, com viés claro ou para motivos pessoais verificáveis | Retiradas permissões para aplicar penalidades por 1 dia | Retiradas permissões para aplicar penalidades por 1 semana | Reavaliação da posição como moderador |
+| Moderador fazendo ameaças constantes de punição a usuários, com viés claro ou para motivos pessoais verificáveis | Retiradas permissões para aplicar penalidades por 1 dia | Retiradas permissões para aplicar penalidades por 1 semana | Reavaliação da posição como moderador |
 
 - Moderadores que descumpram as regras que são válidas para todos os usuários tem suas permissões para aplicar penalidades retiradas e recebem a mesma penalidade que um usuário comum recebe, recebendo novamente as permissões para aplicar penalidades apenas após cumprir a penalidade recebida.
 

--- a/penalidades.md
+++ b/penalidades.md
@@ -1,0 +1,20 @@
+# Lista de Penalidades
+
+>Penalidades aplicáveis a membros que descumpram com as regras listadas em nosso código de conduta.
+
+#### Penalidades para o grupo Cypherpunks Brasil no telegram:
+
+| Ocorrência | 1º incidente | 2º incidente | 3º incidente + |
+|------------|--------------|--------------|----------------|
+| Comportamentos propositalmente e insistentemente insultuosos e/ou discussões acaloradas em que várias pessoas se insultem mutuamente | Mensagem apagada, mute de 6 horas | Mensagem apagada, mute de 2 dias | Mensagem apagada, mutes de 2 semanas |
+| Ameaça séria e crível de violência física contra outro membro | Mensagem apagada, ban | - | - |
+| Doxxing de membros | Mensagem apagada, ban | - | - |
+| Comportamentos scriptados/automáticos de flood/spam, anúncios/publicidade de usuário que não participa do grupo ou acaba de entrar ou não-autorizada | mute de 2 dias | mute de 2 semanas | ban |
+| Tentativa de enganar usuários com scam, golpes, fraude ou outros atos claramente ilegais | ban | - | - |
+| Offtopic ostensivo ou inflamado | Envio do link para o offtopic, mute de 1 hora | Envio do link para o offtopic, mute de 1 dia | Envio do link para o offtopic, mute de 2 dias a cada incidente |
+| Conteúdos _NSFW_ | Mensagem apagada, mute de 6 horas | Mensagem apagada, mute de 5 dias | Mensagem apagada, mute de 2 semanas a cada incidente |
+| Moderado fazendo ameaças constantes de punição a usuários, com viés claro ou para motivos pessoais verificáveis | Retiradas permissões para aplicar penalidades por 1 dia | Retiradas permissões para aplicar penalidades por 1 semana | Reavaliação da posição como moderador |
+
+- Moderadores que descumpram as regras que são válidas para todos os usuários tem suas permissões para aplicar penalidades retiradas e recebem a mesma penalidade que um usuário comum recebe, recebendo novamente as permissões para aplicar penalidades apenas após cumprir a penalidade recebida.
+
+As regras listadas estão simplificadas, porém em concordância com o [Código de Conduta](https://github.com/cypherpunksbr/comunidade/blob/main/CODE_OF_CONDUCT.md).

--- a/penalidades.md
+++ b/penalidades.md
@@ -17,6 +17,6 @@
 
 - Moderadores que descumpram as regras que são válidas para todos os usuários tem suas permissões para aplicar penalidades retiradas e recebem a mesma penalidade que um usuário comum recebe, recebendo novamente as permissões para aplicar penalidades apenas após cumprir a penalidade recebida.
 
-- Os moderadores tem autonomia para penalizar usuários e as penalidades podem ser sutilmente alteradas caso os casos tenham gravidade menor ou maior, jamais levando para o lado pessoal. Moderadores que não usarem do bom senso serão afastados.
+- Os moderadores tem autonomia para penalizar usuários e as penalidades podem ser sutilmente alteradas caso as ocorrências tenham gravidade desproporcional. Moderadores que não usarem do bom senso e imparcialidade serão afastados.
 
 As regras listadas estão simplificadas, porém em concordância com o [Código de Conduta](https://github.com/cypherpunksbr/comunidade/blob/main/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
Houve descontentamento de alguns membros do grupo do telegram referente a criação do CoC, algumas foram por não entendimento e má vontade e outras foram legítimas, especialmente por que alguns tópicos estavam mal organizados e permitiam interpretações abrangentes demais, deixando os membros na dúvida se deveriam ou não postar algo, como por exemplo a dúvida do que se encaixa em on-topic e off-topic.
Por isso o CoC foi afrouxado, os tópicos foram melhor organizados e foi criada uma lista de penalidades clara para membros e moderadores.